### PR TITLE
Add silo create

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "next": "15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "uid": "^2.0.2",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -1290,6 +1291,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -7174,6 +7184,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "uid": "^2.0.2",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/src/components/silo/SiloCreateForm.tsx
+++ b/src/components/silo/SiloCreateForm.tsx
@@ -46,8 +46,10 @@ export default function SiloCreateForm() {
 
   const createSilo = async () => {
     try {
-      const silo = { name: formData.name, description: formData.description };
-      const result = await create(silo);
+      const result = await create({
+          name: formData.name,
+          description: formData.description 
+      });
       if (result === null) {
         setError("Firebase foutmelding (zie console)");
         return;

--- a/src/components/silo/SiloCreateForm.tsx
+++ b/src/components/silo/SiloCreateForm.tsx
@@ -1,5 +1,90 @@
+"use client";
+
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import { create } from "@/lib/silo";
+import { createSchema } from "@/lib/validation/silo";
+import { useRouter } from "next/navigation";
+import { ChangeEvent, FormEvent, useState } from "react";
+
 export default function SiloCreateForm() {
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setIsLoading(true);
+
+    if (validateSchema()) {
+      await createSilo();
+    }
+
+    setIsLoading(false);
+  };
+
+  const validateSchema = (): boolean => {
+    const result = createSchema.safeParse(formData);
+    if (result.error) {
+      setError(result.error.errors[0].message);
+      return false;
+    }
+    return true;
+  };
+
+  const createSilo = async () => {
+    try {
+      const silo = { name: formData.name, description: formData.description };
+      const result = await create(silo);
+      if (result === null) {
+        setError("Firebase foutmelding (zie console)");
+        return;
+      }
+      setSuccess("Silo aangemaakt. Even geduld...");
+      router.push('/silo');
+    } catch (error: any) { // eslint-disable-line
+      setError(error.message || "Er is een onbeschrijfelijke fout opgetreden");
+    }
+  };
+
   return (
-    <></>
+    <div className="text-center">
+
+      <h1>Maak een nieuwe silo aan</h1>
+
+      <form className="flex flex-col" onSubmit={handleSubmit}>
+        <Input
+          name="name"
+          placeholder="Naam"
+          type="text"
+          value={formData.name}
+          onChange={handleInputChange}
+        />
+        <Input
+          name="description"
+          placeholder="Omschrijving"
+          type="text"
+          value={formData.description}
+          onChange={handleInputChange}
+        />
+        <Button disabled={isLoading} label="Silo aanmaken" type="submit" />
+
+        {error && <p className="text-red-500">{error}</p>}
+        {success && <p className="text-green-500">{success}</p>}
+      </form>
+
+    </div>
   );
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,11 +2,22 @@ import { app } from "@/lib/firebase";
 import {
   createUserWithEmailAndPassword,
   getAuth,
+  onAuthStateChanged,
   signInWithEmailAndPassword,
+  User,
   UserCredential
 } from "firebase/auth";
 
 const auth = getAuth(app);
+
+let authUser: User | null = null;
+onAuthStateChanged(auth, (user) => {
+  authUser = user;
+});
+
+export function getAuthUser(): User | null {
+  return authUser;
+}
 
 export async function signUp(
   email: string,

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,4 +1,5 @@
 import { initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_API_KEY,
@@ -11,3 +12,4 @@ const firebaseConfig = {
 };
 
 export const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/src/lib/silo.ts
+++ b/src/lib/silo.ts
@@ -1,4 +1,10 @@
+import { getAuthUser } from "@/lib/auth";
+import { db } from "@/lib/firebase";
 import { Silo } from "@/types/silo";
+import { doc, setDoc } from "firebase/firestore";
+import { uid } from "uid";
+
+const documentName = "silos";
 
 export async function getByUid(Uid: string): Promise<Silo> {
   return { uid: "", name: "", description: "", ownerUid: "" };
@@ -8,8 +14,15 @@ export async function getAll(): Promise<Silo[]> {
   return [{ uid: "", name: "", description: "", ownerUid: "" }];
 }
 
-export async function create(silo: Silo): Promise<Silo> {
-  return { uid: "", name: "", description: "", ownerUid: "" };
+export async function create(silo: Silo): Promise<Silo | null> {
+  try {
+    silo = { ...silo, uid: uid(32), ownerUid: getAuthUser()?.uid };
+    await setDoc(doc(db, documentName, String(silo.uid)), silo);
+    return silo;
+  } catch (error: any) { // eslint-disable-line
+    console.error("Firebase foutmelding, details in console:", error.code);
+    return null;
+  }
 }
 
 export async function update(silo: Silo): Promise<Silo> {

--- a/src/lib/silo.ts
+++ b/src/lib/silo.ts
@@ -6,7 +6,7 @@ import { uid } from "uid";
 
 const documentName = "silos";
 
-export async function getByUid(Uid: string): Promise<Silo> {
+export async function getByUid(Uid: string): Promise<Silo> { // eslint-disable-line
   return { uid: "", name: "", description: "", ownerUid: "" };
 }
 
@@ -25,6 +25,6 @@ export async function create(silo: Silo): Promise<Silo | null> {
   }
 }
 
-export async function update(silo: Silo): Promise<Silo> {
+export async function update(silo: Silo): Promise<Silo> { // eslint-disable-line
   return { uid: "", name: "", description: "", ownerUid: "" };
 }

--- a/src/lib/validation/silo.ts
+++ b/src/lib/validation/silo.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
 
-export const createSchema = z.object({});
+export const createSchema = z.object({
+  name: z
+    .string()
+    .min(3, { message: "De naam moet minimaal 3 karakters lang zijn"}),
+  description: z
+    .string(),
+});
 export const updateSchema = z.object({});

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -3,7 +3,7 @@ import { ChangeEvent } from "react";
 export interface Input {
   name: string;
   placeholder: string;
-  type: "email" | "password";
+  type: "text" | "email" | "password";
   value?: string | undefined;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }

--- a/src/types/silo.ts
+++ b/src/types/silo.ts
@@ -1,6 +1,6 @@
-export interface Silo {
-  uid: string;
+export type Silo = {
+  uid?: string;
   name: string;
   description: string;
-  ownerUid: string;
+  ownerUid?: string;
 }

--- a/src/types/silo.ts
+++ b/src/types/silo.ts
@@ -1,6 +1,6 @@
 export type Silo = {
   uid?: string;
   name: string;
-  description: string;
+  description?: string;
   ownerUid?: string;
 }


### PR DESCRIPTION
Ik merk dat de form afhandeling erg op elkaar lijkt. Denk aan de volgende onderdelen: `error`, `success`, `loading`, `handleInputChange`, `validateSchema` en `create*`. Er komen nog veel forms aan, waardoor het mij handig lijkt om hier ff samen over na te denken.

Je kan het testen via de route `/silo/create`.