### PR TITLE
Give Firestore some time off

### DIFF
--- a/src/components/silo/SiloIndex.tsx
+++ b/src/components/silo/SiloIndex.tsx
@@ -4,7 +4,7 @@ import SiloCreateCta from "@/components/silo/SiloCreateCta";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { getAuthUserUid } from "@/lib/auth";
-import { getAllByOwnerUid } from "@/lib/silo";
+import { listenForByOwnerUid } from "@/lib/silo";
 import { Silo } from "@/types/silo";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -14,15 +14,14 @@ export default function SiloIndex() {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const fetchSilos = async () => {
-      const authUserUid = getAuthUserUid() ?? "";
-      const data = await getAllByOwnerUid(authUserUid);
-      setIsLoading(false);
-      setSilos(data);
-    }
+    const authUserUid = getAuthUserUid() ?? "";
+    const unsubscribe = listenForByOwnerUid(authUserUid, (silos: Silo[]) => {
+      setSilos(silos);
+    });
+    setIsLoading(false);
 
-    fetchSilos();
-  });
+    return () => unsubscribe();
+  }, []);
 
   return (
     <div className="flex flex-col w-96">

--- a/src/components/silo/SiloIndex.tsx
+++ b/src/components/silo/SiloIndex.tsx
@@ -15,9 +15,12 @@ export default function SiloIndex() {
 
   useEffect(() => {
     const authUserUid = getAuthUserUid() ?? "";
-    const unsubscribe = listenForByOwnerUid(authUserUid, (silos: Silo[]) => {
-      setSilos(silos);
-    });
+    const unsubscribe = listenForByOwnerUid(
+      authUserUid,
+      (silos: Silo[]) => {
+        setSilos(silos);
+      }
+    );
     setIsLoading(false);
 
     return () => unsubscribe();


### PR DESCRIPTION
De oude implementatie van "realtime updates" was onderwater Firestore aan het spammen met read requests. Nu wordt de `onSnapshot` gebruikt wat het aantal requests drastisch verminderd. Je kan deze PR valideren door naar je _Network_ tab te kijken in de browser en die vergelijken met eerst. De realtime updates kunnen gevalideerd worden door twee tabs te openen, waarvan er een is op de route `/silo` en de ander die een nieuwe silo aanmaakt (route: `/silo/create`). Zorg er wel voor dat je op hetzelfde account bent ingelogd.