### PR TITLE
Add simple silo archive

### DIFF
--- a/src/app/silo/archive/page.tsx
+++ b/src/app/silo/archive/page.tsx
@@ -1,0 +1,10 @@
+import SiloLayout from "@/app/silo/layout"
+import SiloArchive from "@/components/silo/SiloArchive"
+
+export default function SiloArchivePage() {
+  return (
+    <SiloLayout>
+      <SiloArchive />
+    </SiloLayout>
+  )
+}

--- a/src/components/silo/SiloArchive.tsx
+++ b/src/components/silo/SiloArchive.tsx
@@ -1,15 +1,14 @@
 "use client"
 
-import SiloCreateCta from "@/components/silo/SiloCreateCta"
 import Button from "@/components/ui/Button"
 import EmptyState from "@/components/ui/EmptyState"
 import { useAuth } from "@/hooks/useAuth"
-import { archive, listenForByOwnerUid } from "@/lib/silo"
+import { listenForByOwnerUid, unarchive } from "@/lib/silo"
 import { Silo } from "@/types/silo"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 
-export default function SiloIndex() {
+export default function SiloArchive() {
   const [silos, setSilos] = useState<Silo[] | null>(null)
   const { currentUser } = useAuth()
 
@@ -17,21 +16,21 @@ export default function SiloIndex() {
     const unsubscribe = listenForByOwnerUid(
       currentUser?.uid ?? "",
       (silos: Silo[]) => {
-        const activeSilos = silos.filter((silo) => !silo.isArchived)
-        setSilos(activeSilos)
+        const archivedSilos = silos.filter((silo) => silo.isArchived)
+        setSilos(archivedSilos)
       }
     )
     return () => unsubscribe()
   }, [currentUser?.uid])
 
-  const archiveSilo = async (silo: Silo) => {
-    await archive(silo?.uid ?? "")
+  const unarchiveSilo = async (silo: Silo) => {
+    await unarchive(silo?.uid ?? "")
   }
 
   return (
     <div className="flex flex-col w-96">
 
-      <h1 className="text-center font-bold text-lg">Jouw silos</h1>
+      <h1 className="text-center font-bold text-lg">Jouw silo archief</h1>
 
       <ul>
         {silos && silos.length > 0 ? (
@@ -45,26 +44,18 @@ export default function SiloIndex() {
                 {silo.description && <p className="italic">{silo.description}</p>}
               </div>
               <div className="space-x-2">
-                <Link className="underline" href={`/silo/edit/${silo.uid}`}>
-                  Wijzig
-                </Link>
-                <Button label="Archiveren" onClick={() => archiveSilo(silo)} />
+                <Button label="Dearchiveren" onClick={() => unarchiveSilo(silo)} />
               </div>
             </li>
           ))
         ) : (
-          silos && <EmptyState cta={<SiloCreateCta />} />
+          silos && <EmptyState />
         )}
       </ul>
 
-      <div className="flex justify-between">
-        <Link className="underline" href="/silo/create">
-          Nieuwe silo aanmaken
-        </Link>
-        <Link className="underline" href="/silo/archive">
-          Naar archief
-        </Link>
-      </div>
+      <Link className="underline" href="/silo">
+        Terug naar overzicht
+      </Link>
 
     </div>
   )

--- a/src/components/silo/SiloEditForm.tsx
+++ b/src/components/silo/SiloEditForm.tsx
@@ -2,8 +2,9 @@
 
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
-import { getByUid, update } from "@/lib/silo";
+import { archive, getByUid, update } from "@/lib/silo";
 import { updateSchema } from "@/lib/validation/silo";
+import { Silo } from "@/types/silo";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ChangeEvent, FormEvent, useEffect, useState } from "react";
@@ -13,6 +14,7 @@ export default function SiloEditForm({ uid }: { uid: string }) {
     name: "",
     description: "",
   });
+  const [silo, setSilo] = useState<Silo | null>(null)
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -25,6 +27,7 @@ export default function SiloEditForm({ uid }: { uid: string }) {
         name: silo?.name ?? "",
         description: silo?.description ?? ""
       });
+      setSilo(silo)
     }
     fetchSilo();
   }, [uid]);
@@ -76,6 +79,11 @@ export default function SiloEditForm({ uid }: { uid: string }) {
     }
   };
 
+  const archiveSilo = async () => {
+    await archive(silo?.uid ?? "")
+    router.push('/silo')
+  }
+
   return (
     <div className="text-center">
 
@@ -98,6 +106,7 @@ export default function SiloEditForm({ uid }: { uid: string }) {
         />
         <div className="pt-2 flex justify-between items-center">
           <Link className="underline" href="/silo">Annuleren</Link>
+          <Button label="Archiveren" onClick={archiveSilo} />
           <Button disabled={isSubmitting} label="Silo aanpassen" type="submit" />
         </div>
 

--- a/src/components/silo/SiloIndex.tsx
+++ b/src/components/silo/SiloIndex.tsx
@@ -24,10 +24,6 @@ export default function SiloIndex() {
     return () => unsubscribe()
   }, [currentUser?.uid])
 
-  const archiveSilo = async (silo: Silo) => {
-    await archive(silo?.uid ?? "")
-  }
-
   return (
     <div className="flex flex-col w-96">
 
@@ -48,7 +44,6 @@ export default function SiloIndex() {
                 <Link className="underline" href={`/silo/edit/${silo.uid}`}>
                   Wijzig
                 </Link>
-                <Button label="Archiveren" onClick={() => archiveSilo(silo)} />
               </div>
             </li>
           ))

--- a/src/components/silo/SiloIndex.tsx
+++ b/src/components/silo/SiloIndex.tsx
@@ -1,10 +1,9 @@
 "use client"
 
 import SiloCreateCta from "@/components/silo/SiloCreateCta"
-import Button from "@/components/ui/Button"
 import EmptyState from "@/components/ui/EmptyState"
 import { useAuth } from "@/hooks/useAuth"
-import { archive, listenForByOwnerUid } from "@/lib/silo"
+import { listenForByOwnerUid } from "@/lib/silo"
 import { Silo } from "@/types/silo"
 import Link from "next/link"
 import { useEffect, useState } from "react"

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,9 +1,9 @@
-import { Button as ButtonType } from "@/types/ui";
+import { Button as ButtonType } from "@/types/ui"
 
 export default function Button({
-  disabled,
+  disabled = false,
   label,
-  type,
+  type = "button",
   onClick
 }: ButtonType) {
   return (
@@ -15,5 +15,5 @@ export default function Button({
     >
       {label}
     </button>
-  );
+  )
 }

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,12 +1,10 @@
-import { ReactNode } from "react";
+import { ReactNode } from "react"
 
-export default function EmptyState({ cta }: { cta: ReactNode }) {
+export default function EmptyState({ cta }: { cta?: ReactNode }) {
   return (
     <div className="border text-center p-4">
       <p>Oeps, er lijkt geen data beschikbaar te zijn!</p>
-      <div className="pt-4">
-        {cta}
-      </div>
+      {cta && <div className="pt-4">{cta}</div>}
     </div>
-  );
+  )
 }

--- a/src/lib/silo.ts
+++ b/src/lib/silo.ts
@@ -1,6 +1,6 @@
-import { db } from "@/lib/firebase";
-import { Silo } from "@/types/silo";
-import { Unsubscribe } from "firebase/auth";
+import { db } from "@/lib/firebase"
+import { Silo } from "@/types/silo"
+import { Unsubscribe } from "firebase/auth"
 import {
   collection,
   doc,
@@ -10,19 +10,19 @@ import {
   setDoc,
   updateDoc,
   where
-} from "firebase/firestore";
-import { uid } from "uid";
+} from "firebase/firestore"
+import { uid } from "uid"
 
-const documentName = "silos";
+const documentName = "silos"
 
 export async function getByUid(uid: string): Promise<Silo | null> {
   try {
-    const docRef = doc(db, documentName, uid);
-    const docSnap = await getDoc(docRef);
-    return docSnap.exists() ? docSnap.data() as Silo : null;
+    const docRef = doc(db, documentName, uid)
+    const docSnap = await getDoc(docRef)
+    return docSnap.exists() ? docSnap.data() as Silo : null
   } catch (error: any) { // eslint-disable-line
-    console.error("Firebase foutmelding, details in console:", error.code);
-    return null;
+    console.error("Firebase foutmelding, details in console:", error.code)
+    return null
   }
 }
 
@@ -33,21 +33,21 @@ export function listenForByOwnerUid(
   const q = query(
     collection(db, documentName),
     where("ownerUid", "==", ownerUid)
-  );
+  )
   const unsubscribe = onSnapshot(
     q,
     (querySnapshot) => {
-      const silos: Silo[] = [];
+      const silos: Silo[] = []
       querySnapshot.forEach((doc) => {
-        silos.push(doc.data() as Silo);
-      });
-      callback(silos);
+        silos.push(doc.data() as Silo)
+      })
+      callback(silos)
     },
     (error) => {
-      console.error("Firebase foutmelding, details in console:", error.code);
+      console.error("Firebase foutmelding, details in console:", error.code)
     }
-  );
-  return unsubscribe;
+  )
+  return unsubscribe
 }
 
 export async function create(
@@ -55,12 +55,12 @@ export async function create(
   ownerUid: string
 ): Promise<Silo | null> {
   try {
-    silo = { ...silo, uid: uid(32), ownerUid: ownerUid};
-    await setDoc(doc(db, documentName, String(silo.uid)), silo);
-    return silo;
+    silo = { ...silo, uid: uid(32), ownerUid: ownerUid}
+    await setDoc(doc(db, documentName, String(silo.uid)), silo)
+    return silo
   } catch (error: any) { // eslint-disable-line
-    console.error("Firebase foutmelding, details in console:", error.code);
-    return null;
+    console.error("Firebase foutmelding, details in console:", error.code)
+    return null
   }
 }
 
@@ -69,11 +69,27 @@ export async function update(
   nextSilo: Silo
 ): Promise<Silo | null> {
   try {
-    const docRef = doc(db, documentName, uid);
-    await updateDoc(docRef, nextSilo);
-    return nextSilo;
+    const docRef = doc(db, documentName, uid)
+    await updateDoc(docRef, nextSilo)
+    return nextSilo
   } catch (error: any) { // eslint-disable-line
-    console.error("Firebase foutmelding, details in console:", error.code);
-    return null;
+    console.error("Firebase foutmelding, details in console:", error.code)
+    return null
   }
+}
+
+export async function archive(uid: string): Promise<Silo | null> {
+  const silo = await getByUid(uid)
+  if (silo !== null) {
+    return await update(uid, { ...silo, isArchived: true })
+  }
+  return null
+}
+
+export async function unarchive(uid: string): Promise<Silo | null> {
+  const silo = await getByUid(uid)
+  if (silo !== null) {
+    return await update(uid, { ...silo, isArchived: false })
+  }
+  return null
 }

--- a/src/types/silo.ts
+++ b/src/types/silo.ts
@@ -1,6 +1,7 @@
 export type Silo = {
-  uid?: string;
-  name: string;
-  description?: string;
-  ownerUid?: string;
+  uid?: string
+  name: string
+  description?: string
+  isArchived?: boolean
+  ownerUid?: string
 }

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,16 +1,16 @@
-import { ChangeEvent, FormEvent } from "react";
+import { ChangeEvent, FormEvent } from "react"
 
 export interface Button {
-  disabled: boolean;
-  label: string;
-  type: "submit";
-  onClick?: (e: FormEvent<HTMLButtonElement>) => void;
+  disabled?: boolean
+  label: string
+  type?: "button" | "submit"
+  onClick?: (e: FormEvent<HTMLButtonElement>) => void
 }
 
 export interface Input {
-  name: string;
-  placeholder: string;
-  type: "text" | "email" | "password";
-  value?: string | undefined;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  name: string
+  placeholder: string
+  type: "text" | "email" | "password"
+  value?: string | undefined
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
 }


### PR DESCRIPTION
Bestaande silos kunnen nu in en uit het archief van een gebruiker worden geplaatst.

Overzicht:
![image](https://github.com/user-attachments/assets/373dbe2c-20b7-4bbf-a192-eee2c03b2964)

Archief (leeg):
![image](https://github.com/user-attachments/assets/29810ed4-ae33-4047-87a5-275f7cb5b821)

Archief (gevuld):
![image](https://github.com/user-attachments/assets/cc66b5ae-aede-4295-8dee-06cfee0de311)
